### PR TITLE
feat: Implement clipboard hijacking and auto-open feature

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -1,6 +1,15 @@
 console.log("NS4F: Service Worker script executing.");
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.action === "auto_open_tab") {
+        console.log("NS4F: Received auto_open_tab action with URL:", request.url);
+        if (request.url) {
+            chrome.tabs.create({ url: request.url });
+        }
+        // No response needed for this action
+        return;
+    }
+
     if (request.action === "ns4f_share") {
         console.log("NS4F: Received share action with data:", request.data);
 

--- a/src/content/content-script.js
+++ b/src/content/content-script.js
@@ -19,6 +19,14 @@ window.addEventListener('message', (ev) => {
   if (url) {
     console.log("NS4F: Intercepted a copied URL:", url);
     lastCopiedUrl = { url, t: Date.now() };
+
+    // Check if the auto-open feature is enabled and send a message if so.
+    chrome.storage.sync.get({ autoOpen: false }, (items) => {
+      if (items.autoOpen) {
+        console.log("NS4F: Auto-open is enabled. Sending message to background script.");
+        chrome.runtime.sendMessage({ action: 'auto_open_tab', url: url });
+      }
+    });
   }
 });
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -24,6 +24,12 @@
       <label for="database-id">Notion Database ID</label>
       <input type="text" id="database-id" name="database-id" required>
     </div>
+    <div class="form-group">
+      <label>
+        <input type="checkbox" id="auto-open" name="auto-open">
+        複製連結後，自動在新分頁中開啟 (Auto-open copied links in a new tab)
+      </label>
+    </div>
     <button type="submit">Save Settings</button>
   </form>
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -5,11 +5,13 @@ console.log("NS4F: Options script executing.");
 function save_options() {
   const notionToken = document.getElementById('notion-token').value;
   const databaseId = document.getElementById('database-id').value;
+  const autoOpen = document.getElementById('auto-open').checked;
 
   // The chrome.storage API is asynchronous.
   chrome.storage.sync.set({
     notionToken: notionToken,
-    databaseId: databaseId
+    databaseId: databaseId,
+    autoOpen: autoOpen
   }, function() {
     // Update status to let user know options were saved.
     const status = document.getElementById('status');
@@ -23,13 +25,15 @@ function save_options() {
 // Restores select box and checkbox state using the preferences
 // stored in chrome.storage.
 function restore_options() {
-  // Use default value for notionToken and databaseId
+  // Use default value for notionToken, databaseId, and autoOpen
   chrome.storage.sync.get({
     notionToken: '',
-    databaseId: ''
+    databaseId: '',
+    autoOpen: false // Default to false
   }, function(items) {
     document.getElementById('notion-token').value = items.notionToken;
     document.getElementById('database-id').value = items.databaseId;
+    document.getElementById('auto-open').checked = items.autoOpen;
   });
 }
 


### PR DESCRIPTION
Implements a robust clipboard hijacking mechanism to capture post URLs and adds a user-configurable option to automatically open the captured link in a new tab.

- Replaces DOM-based 'Copy Link' button hijacking with a more resilient strategy that intercepts clipboard events via an injected script.
- The URL extraction logic is updated to prioritize this recently copied URL.
- Adds an 'Auto-open copied links' checkbox to the options page.
- If enabled, the extension will open the captured URL in a new tab immediately after it's copied.